### PR TITLE
Fix: List org runners pagination call

### DIFF
--- a/.circleci/build_and_publish.sh
+++ b/.circleci/build_and_publish.sh
@@ -2,7 +2,7 @@
 
 REGISTRY_URL=docker.tw.ee
 COMMIT=${CIRCLE_SHA1:0:8}
-TAG=v0.2.1-${COMMIT}
+TAG=v0.2.2-${COMMIT}
 
 echo "Building images"
 

--- a/collector.go
+++ b/collector.go
@@ -48,14 +48,28 @@ func init() {
 // listOfOrgRunners returns the runners in an organizations
 func listOfOrgRunners() (*githubRunners, error) {
 	ctx := context.Background()
+	opts := &github.ListOptions{
+		PerPage: 99,
+	}
 
-	r, _, err := ghClient.Client.Actions.ListOrganizationRunners(ctx, ghClient.Organization, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving runners: %s", err)
+	var r []*github.Runner
+	for {
+		runners, resp, err := ghClient.Client.Actions.ListOrganizationRunners(ctx, ghClient.Organization, opts)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving runners: %s", err)
+		}
+		r = append(r, runners.Runners...)
+		if resp.NextPage == 0 {
+			break
+		}
+		opts.Page = resp.NextPage
 	}
 
 	return &githubRunners{
-		Runners: r,
+		&github.Runners{
+			Runners:    r,
+			TotalCount: len(r),
+		},
 	}, nil
 }
 


### PR DESCRIPTION
## Context

Looks like we have an issue in exporter, because api call for list org runners returns paged response, with default limit of 30 runners.

### Changes

add pagination to API call

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
