### PR TITLE
update codeowners for new ci team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @transferwise/sp-automation-tooling
+* @transferwise/continuous-integration


### PR DESCRIPTION
## Context

This PR updates the codeowners from A&T to continuous-integration

https://transferwise.atlassian.net/browse/PAT-1595

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
